### PR TITLE
feat(concurrency): CB-213 implement optimistic locking and transactional safety

### DIFF
--- a/backend/docs/CB-213-DONE.md
+++ b/backend/docs/CB-213-DONE.md
@@ -1,0 +1,23 @@
+# CB-213 DONE
+
+**Ticket:** CB-213 — Concurrency Safety
+**Branch:** `feature/cb-213-concurrency-safety`
+**Status:** ✅ Complete
+**Commit:** `e1b0dfc`
+
+## Deliverables
+
+| File | Change |
+|---|---|
+| `model/Post.java` | `@Version Long version` field added |
+| `exception/ConflictException.java` | NEW — maps to HTTP 409 |
+| `exception/GlobalExceptionHandler.java` | Two new handlers: `ConflictException` + `ObjectOptimisticLockingFailureException` |
+| `service/PostService.java` | `@Transactional` on all write methods; `@Transactional(readOnly=true)` on all reads |
+| `service/CommentService.java` | `@Transactional` on all write methods; `@Transactional(readOnly=true)` on reads |
+| `service/PostConcurrencyTest.java` | 6 concurrency tests — all passing |
+
+## Test Results
+
+```
+Tests run: 51, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
+```

--- a/backend/docs/CB-213-TECHNICAL-DOCUMENTATION.md
+++ b/backend/docs/CB-213-TECHNICAL-DOCUMENTATION.md
@@ -1,0 +1,106 @@
+# CB-213 Technical Documentation — Concurrency Safety
+
+## Overview
+
+CB-213 adds concurrency safety to the CommunityBoard backend via optimistic locking on the `Post` entity and explicit `@Transactional` boundaries on all service methods.
+
+---
+
+## 1. Optimistic Locking — `@Version` on `Post`
+
+### What it does
+
+JPA optimistic locking prevents **lost updates** without holding database locks. A `version` column is added to the `posts` table. Every `UPDATE` increments the version automatically. If two concurrent transactions both read `version = 0` and both attempt a write, the second write fails because the DB row now has `version = 1`.
+
+### Implementation
+
+```java
+// Post.java
+@Version
+@Column(nullable = false)
+private Long version;
+```
+
+- **Initial value:** `0` (set by JPA on first insert)
+- **Incremented by:** JPA on every `UPDATE` statement
+- **Failure mode:** `ObjectOptimisticLockingFailureException` → mapped to HTTP 409
+
+---
+
+## 2. Exception Handling — HTTP 409 Conflict
+
+### `ConflictException`
+
+```java
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) { super(message); }
+}
+```
+
+Throw this from service code for domain-level conflicts (e.g., duplicate resource that should be a 409, not a 422).
+
+### `GlobalExceptionHandler` additions
+
+```java
+@ExceptionHandler(ConflictException.class)
+public ResponseEntity<ApiErrorResponse> handleConflict(ConflictException ex) {
+    return build(HttpStatus.CONFLICT, ex.getMessage());
+}
+
+@ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+public ResponseEntity<ApiErrorResponse> handleOptimisticLock(ObjectOptimisticLockingFailureException ex) {
+    return build(HttpStatus.CONFLICT,
+            "This resource was updated by another request. Please reload and try again.");
+}
+```
+
+Both return `HTTP 409 Conflict` with a structured `ApiErrorResponse` body.
+
+---
+
+## 3. Transactional Boundaries
+
+### PostService
+
+| Method | Annotation |
+|---|---|
+| `getAllPosts()` | `@Transactional(readOnly = true)` |
+| `searchPosts()` | `@Transactional(readOnly = true)` |
+| `getPostById()` | `@Transactional(readOnly = true)` |
+| `createPost()` | `@Transactional` |
+| `updatePost()` | `@Transactional` |
+| `deletePost()` | `@Transactional` |
+
+### CommentService
+
+| Method | Annotation |
+|---|---|
+| `getCommentsByPost()` | `@Transactional(readOnly = true)` |
+| `createComment()` | `@Transactional` |
+| `updateComment()` | `@Transactional` |
+| `deleteComment()` | `@Transactional` |
+
+**Why `readOnly=true`?** Hibernate skips dirty-checking on read-only transactions, reducing memory overhead and preventing accidental flushes.
+
+---
+
+## 4. Concurrency Tests — `PostConcurrencyTest`
+
+| Test | What it verifies |
+|---|---|
+| `newPost_hasVersionZero` | `@Version` initialises to `0` on first persist |
+| `successfulUpdate_incrementsVersion` | Version increments `0 → 1 → 2` on sequential writes |
+| `concurrentUpdate_throwsOptimisticLockException` | Saving a stale entity throws `ObjectOptimisticLockingFailureException` |
+| `twoThreadsConcurrentUpdate_onlyOneSucceeds` | Two simultaneous writes → exactly 1 success + 1 failure |
+| `savedPost_isRetrievableById` | Basic persistence smoke-test |
+| `deletePost_removesFromRepository` | Delete cascade smoke-test |
+
+All tests use `@SpringBootTest` with H2 in-memory DB. `@DirtiesContext(AFTER_EACH_TEST_METHOD)` ensures a clean DB per test.
+
+---
+
+## 5. Security Notes
+
+- The version field is **read-only to clients** — it is never included in `PostRequest` DTO, so clients cannot manipulate it.
+- HTTP 409 responses do not expose internal entity state or Hibernate details — only a user-friendly message.
+- `@Transactional` boundaries ensure that partial writes are rolled back on any exception.

--- a/backend/src/main/java/com/amalitech/communityboard/exception/ConflictException.java
+++ b/backend/src/main/java/com/amalitech/communityboard/exception/ConflictException.java
@@ -1,0 +1,8 @@
+package com.amalitech.communityboard.exception;
+
+/** CB-213: Thrown when an optimistic lock conflict is detected (concurrent update). Maps to HTTP 409. */
+public class ConflictException extends RuntimeException {
+    public ConflictException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/amalitech/communityboard/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/amalitech/communityboard/exception/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ import com.amalitech.communityboard.dto.ApiErrorResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -32,6 +33,21 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(DuplicateResourceException.class)
     public ResponseEntity<ApiErrorResponse> handleDuplicate(DuplicateResourceException ex) {
         return build(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    @ExceptionHandler(ConflictException.class)
+    public ResponseEntity<ApiErrorResponse> handleConflict(ConflictException ex) {
+        return build(HttpStatus.CONFLICT, ex.getMessage());
+    }
+
+    /**
+     * CB-213: Handles optimistic locking failures — two concurrent requests tried to update
+     * the same Post version. The second writer gets a 409 Conflict.
+     */
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ApiErrorResponse> handleOptimisticLock(ObjectOptimisticLockingFailureException ex) {
+        return build(HttpStatus.CONFLICT,
+                "This resource was updated by another request. Please reload and try again.");
     }
 
     @ExceptionHandler(UnauthorizedException.class)

--- a/backend/src/main/java/com/amalitech/communityboard/model/Post.java
+++ b/backend/src/main/java/com/amalitech/communityboard/model/Post.java
@@ -61,6 +61,16 @@ public class Post {
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
 
+    /**
+     * CB-213: Optimistic locking version column.
+     * JPA increments this on every UPDATE. If two concurrent transactions read the same
+     * version and both attempt to write, the second write throws
+     * ObjectOptimisticLockingFailureException, preventing a lost update.
+     */
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
     @PrePersist
     protected void onCreate() {
         createdAt = LocalDateTime.now();

--- a/backend/src/main/java/com/amalitech/communityboard/service/CommentService.java
+++ b/backend/src/main/java/com/amalitech/communityboard/service/CommentService.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -23,6 +24,7 @@ public class CommentService {
      * Returns a paginated list of comments for the given post, oldest-first.
      * Page and size default to 0 and 20 respectively if not supplied by the caller.
      */
+    @Transactional(readOnly = true)
     public Page<CommentResponse> getCommentsByPost(Long postId, int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         return commentRepository.findByPostIdOrderByCreatedAtAsc(postId, pageable)
@@ -33,6 +35,7 @@ public class CommentService {
      * Creates a comment on the given post.
      * Throws ResourceNotFoundException (404) if the post does not exist.
      */
+    @Transactional
     public CommentResponse createComment(Long postId, CommentRequest request, User author) {
         Post post = postRepository.findById(postId)
                 .orElseThrow(() -> new ResourceNotFoundException("Post not found with id: " + postId));
@@ -51,6 +54,7 @@ public class CommentService {
      * Throws ResourceNotFoundException (404) if comment does not exist.
      * Throws UnauthorizedException (403) if user is not the author and not ADMIN.
      */
+    @Transactional
     public CommentResponse updateComment(Long commentId, CommentRequest request, User currentUser) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new ResourceNotFoundException("Comment not found with id: " + commentId));
@@ -62,6 +66,7 @@ public class CommentService {
         return toResponse(commentRepository.save(comment));
     }
 
+    @Transactional
     public void deleteComment(Long commentId, User currentUser) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new ResourceNotFoundException("Comment not found with id: " + commentId));

--- a/backend/src/main/java/com/amalitech/communityboard/service/PostService.java
+++ b/backend/src/main/java/com/amalitech/communityboard/service/PostService.java
@@ -19,6 +19,7 @@ import com.amalitech.communityboard.repository.PostRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
 
@@ -30,6 +31,7 @@ public class PostService {
     private final PostRepository postRepository;
     private final CommentRepository commentRepository;
 
+    @Transactional(readOnly = true)
     public Page<PostResponse> getAllPosts(int page, int size) {
         Pageable pageable = PageRequest.of(page, size);
         return postRepository.findAllByOrderByCreatedAtDesc(pageable).map(this::toResponse);
@@ -39,6 +41,7 @@ public class PostService {
      * Searches and filters posts by any combination of category, date range, and keyword.
      * All parameters are optional — passing null disables that filter.
      */
+    @Transactional(readOnly = true)
     public Page<PostResponse> searchPosts(String categoryStr, LocalDateTime startDate,
                                           LocalDateTime endDate, String keyword,
                                           int page, int size) {
@@ -65,12 +68,14 @@ public class PostService {
         return postRepository.findAll(spec, pageable).map(this::toResponse);
     }
 
+    @Transactional(readOnly = true)
     public PostResponse getPostById(Long id) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Post not found with id: " + id));
         return toResponse(post);
     }
 
+    @Transactional
     public PostResponse createPost(PostRequest request, User author) {
         Category category = parseCategory(request.getCategory());
         Post post = Post.builder()
@@ -84,6 +89,7 @@ public class PostService {
         return toResponse(saved);
     }
 
+    @Transactional
     public PostResponse updatePost(Long id, PostRequest request, User author) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Post not found with id: " + id));
@@ -98,6 +104,7 @@ public class PostService {
         return toResponse(postRepository.save(post));
     }
 
+    @Transactional
     public void deletePost(Long id, User author) {
         Post post = postRepository.findById(id)
                 .orElseThrow(() -> new ResourceNotFoundException("Post not found with id: " + id));

--- a/backend/src/test/java/com/amalitech/communityboard/service/PostConcurrencyTest.java
+++ b/backend/src/test/java/com/amalitech/communityboard/service/PostConcurrencyTest.java
@@ -1,0 +1,162 @@
+package com.amalitech.communityboard.service;
+
+import com.amalitech.communityboard.model.Category;
+import com.amalitech.communityboard.model.Post;
+import com.amalitech.communityboard.model.User;
+import com.amalitech.communityboard.model.enums.Role;
+import com.amalitech.communityboard.repository.PostRepository;
+import com.amalitech.communityboard.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * CB-213: Concurrency safety tests.
+ *
+ * Verifies that:
+ * 1. The @Version column on Post prevents lost updates (optimistic locking).
+ * 2. A concurrent second write throws ObjectOptimisticLockingFailureException.
+ * 3. Successful single-threaded updates increment the version counter.
+ */
+@SpringBootTest
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class PostConcurrencyTest {
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private User author;
+    private Post savedPost;
+
+    @BeforeEach
+    void setUp() {
+        author = userRepository.save(User.builder()
+                .email("author@test.com")
+                .name("Test Author")
+                .password("encoded-password")
+                .role(Role.USER)
+                .build());
+
+        savedPost = postRepository.save(Post.builder()
+                .title("Original Title")
+                .body("Original body content")
+                .category(Category.DISCUSSION)
+                .author(author)
+                .build());
+    }
+
+    @Test
+    @DisplayName("@Version field starts at 0 on new post")
+    void newPost_hasVersionZero() {
+        assertThat(savedPost.getVersion()).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("Version increments by 1 on each successful update")
+    void successfulUpdate_incrementsVersion() {
+        // Re-fetch to get a fully managed instance (avoids cascade/orphan issues with detached builder-created entities)
+        Post v0 = postRepository.findById(savedPost.getId()).orElseThrow();
+        v0.setTitle("Updated Title v1");
+        Post afterFirstUpdate = postRepository.saveAndFlush(v0);
+        assertThat(afterFirstUpdate.getVersion()).isEqualTo(1L);
+
+        Post v1 = postRepository.findById(afterFirstUpdate.getId()).orElseThrow();
+        v1.setTitle("Updated Title v2");
+        Post afterSecondUpdate = postRepository.saveAndFlush(v1);
+        assertThat(afterSecondUpdate.getVersion()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("Concurrent update on stale entity throws ObjectOptimisticLockingFailureException")
+    void concurrentUpdate_throwsOptimisticLockException() {
+        // Simulate two transactions both reading the same post at version 0
+        Post staleSnapshot = postRepository.findById(savedPost.getId())
+                .orElseThrow();
+
+        // First update succeeds and bumps version to 1
+        Post freshCopy = postRepository.findById(savedPost.getId()).orElseThrow();
+        freshCopy.setTitle("Winner update");
+        postRepository.saveAndFlush(freshCopy);
+
+        // The stale snapshot still has version 0 — saving it must fail
+        staleSnapshot.setTitle("Losing concurrent update");
+        assertThatThrownBy(() -> postRepository.saveAndFlush(staleSnapshot))
+                .isInstanceOf(ObjectOptimisticLockingFailureException.class);
+    }
+
+    @Test
+    @DisplayName("Only one thread wins when two threads update the same post concurrently")
+    void twoThreadsConcurrentUpdate_onlyOneSucceeds() throws InterruptedException {
+        int threadCount = 2;
+        CountDownLatch readyLatch  = new CountDownLatch(threadCount);
+        CountDownLatch startLatch  = new CountDownLatch(1);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failCount    = new AtomicInteger(0);
+
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+
+        for (int i = 0; i < threadCount; i++) {
+            final int threadIndex = i;
+            executor.submit(() -> {
+                try {
+                    // Both threads load the post before either saves
+                    Post localCopy = postRepository.findById(savedPost.getId()).orElseThrow();
+                    readyLatch.countDown();
+                    startLatch.await(); // wait for both threads to be ready
+
+                    localCopy.setTitle("Thread-" + threadIndex + " update");
+                    postRepository.saveAndFlush(localCopy);
+                    successCount.incrementAndGet();
+                } catch (ObjectOptimisticLockingFailureException e) {
+                    failCount.incrementAndGet();
+                } catch (Exception e) {
+                    // Hibernate may wrap the exception — count it as a locking failure
+                    if (e.getCause() instanceof ObjectOptimisticLockingFailureException) {
+                        failCount.incrementAndGet();
+                    }
+                }
+            });
+        }
+
+        readyLatch.await();  // wait until both threads have read the entity
+        startLatch.countDown(); // fire both updates simultaneously
+        executor.shutdown();
+        executor.awaitTermination(5, java.util.concurrent.TimeUnit.SECONDS);
+
+        // Exactly one winner, exactly one failure
+        assertThat(successCount.get() + failCount.get()).isEqualTo(threadCount);
+        assertThat(successCount.get()).isEqualTo(1);
+        assertThat(failCount.get()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Saved post is persisted and retrievable by ID")
+    void savedPost_isRetrievableById() {
+        Post found = postRepository.findById(savedPost.getId()).orElseThrow();
+        assertThat(found.getTitle()).isEqualTo("Original Title");
+        assertThat(found.getVersion()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("Post delete removes the record from the repository")
+    void deletePost_removesFromRepository() {
+        Long id = savedPost.getId();
+        postRepository.deleteById(id);
+        assertThat(postRepository.findById(id)).isEmpty();
+    }
+}


### PR DESCRIPTION
## Summary
Implements CB-213: concurrency safety via JPA optimistic locking and explicit
transactional boundaries.

## Changes

### Optimistic Locking
- `Post.java`: added `@Version Long version` — JPA increments on every UPDATE;
  concurrent stale writes throw `ObjectOptimisticLockingFailureException`

### Exception Handling (HTTP 409)
- `ConflictException.java` (NEW): domain-level conflict → 409
- `GlobalExceptionHandler.java`: handlers for `ConflictException` and
  `ObjectOptimisticLockingFailureException` — both return structured 409 responses

### Transactional Boundaries
- `PostService.java`: `@Transactional(readOnly=true)` on all reads,
  `@Transactional` on all writes
- `CommentService.java`: same pattern

### Tests
- `PostConcurrencyTest.java`: 6 @SpringBootTest tests covering version
  initialisation, sequential increments, stale-entity rejection, and
  two-thread concurrent write race

## Test Results
Tests run: 51, Failures: 0, Errors: 0, Skipped: 0