### PR TITLE
fix(auth): resolve QA-reported auth endpoint bugs

### DIFF
--- a/backend/src/main/java/com/amalitech/communityboard/config/SecurityConfig.java
+++ b/backend/src/main/java/com/amalitech/communityboard/config/SecurityConfig.java
@@ -45,6 +45,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 // Public: auth endpoints
                 .requestMatchers("/api/auth/**").permitAll()
+                // Allow Spring Boot's internal error forwarding — prevents 401 masking real errors
+                .requestMatchers("/error").permitAll()
                 // Public: read posts and categories (no auth needed to browse)
                 .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/categories/**").permitAll()

--- a/backend/src/main/java/com/amalitech/communityboard/dto/AuthRequest.java
+++ b/backend/src/main/java/com/amalitech/communityboard/dto/AuthRequest.java
@@ -7,7 +7,8 @@ import lombok.*;
 @Getter @Setter @NoArgsConstructor @AllArgsConstructor
 public class AuthRequest {
     @NotBlank(message = "Email is required")
-    @Email(message = "Email must be a valid email address")
+    @Email(regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+           message = "Email must be a valid email address")
     private String email;
 
     @NotBlank(message = "Password is required")

--- a/backend/src/main/java/com/amalitech/communityboard/dto/RegisterRequest.java
+++ b/backend/src/main/java/com/amalitech/communityboard/dto/RegisterRequest.java
@@ -2,6 +2,7 @@ package com.amalitech.communityboard.dto;
 
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 
@@ -9,10 +10,13 @@ import lombok.*;
 public class RegisterRequest {
     @NotBlank(message = "Name is required")
     @Size(max = 100, message = "Name must not exceed 100 characters")
+    @Pattern(regexp = "^[A-Za-z\\s'\\-]+$",
+             message = "Name must contain only letters, spaces, hyphens, or apostrophes")
     private String name;
 
     @NotBlank(message = "Email is required")
-    @Email(message = "Email must be a valid email address")
+    @Email(regexp = "^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$",
+           message = "Email must be a valid email address")
     private String email;
 
     @NotBlank(message = "Password is required")

--- a/backend/src/main/java/com/amalitech/communityboard/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/amalitech/communityboard/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.FieldError;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
@@ -52,6 +53,12 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ApiErrorResponse> handleUnreadable(HttpMessageNotReadableException ex) {
         return build(HttpStatus.BAD_REQUEST, "Request body is missing or malformed");
+    }
+
+    /** Handles unsupported HTTP methods (e.g. GET on a POST-only endpoint) — returns 405. */
+    @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+    public ResponseEntity<ApiErrorResponse> handleMethodNotAllowed(HttpRequestMethodNotSupportedException ex) {
+        return build(HttpStatus.METHOD_NOT_ALLOWED, ex.getMessage());
     }
 
     /** Catch-all for unexpected RuntimeExceptions — keeps internals out of responses. */

--- a/backend/src/main/java/com/amalitech/communityboard/model/User.java
+++ b/backend/src/main/java/com/amalitech/communityboard/model/User.java
@@ -1,6 +1,7 @@
 package com.amalitech.communityboard.model;
 
 import com.amalitech.communityboard.model.enums.Role;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.*;
 import java.time.LocalDateTime;
@@ -20,6 +21,7 @@ public class User {
     @Column(nullable = false, length = 100)
     private String name;
 
+    @JsonIgnore
     @Column(nullable = false, length = 255)
     private String password;
 

--- a/backend/src/main/java/com/amalitech/communityboard/service/AuthService.java
+++ b/backend/src/main/java/com/amalitech/communityboard/service/AuthService.java
@@ -24,16 +24,16 @@ public class AuthService {
             throw new DuplicateResourceException("Email already registered: " + request.getEmail());
         }
         User user = User.builder()
-                .name(request.getName())
-                .email(request.getEmail())
+                .name(request.getName().trim())
+                .email(request.getEmail().trim().toLowerCase())
                 .password(passwordEncoder.encode(request.getPassword()))
                 .role(Role.USER)
                 .build();
-        userRepository.save(user);
-        String token = jwtService.generateToken(user.getEmail(), user.getRole().name());
+        User savedUser = userRepository.save(user);
+        String token = jwtService.generateToken(savedUser.getEmail(), savedUser.getRole().name());
         return AuthResponse.builder()
-                .id(user.getId()).token(token).email(user.getEmail())
-                .name(user.getName()).role(user.getRole().name()).build();
+                .id(savedUser.getId()).token(token).email(savedUser.getEmail())
+                .name(savedUser.getName()).role(savedUser.getRole().name()).build();
     }
 
     public AuthResponse login(AuthRequest request) {


### PR DESCRIPTION
## Summary
Fixes all auth-related bugs reported by QA across the registration and login endpoints.

## Bugs Fixed

1. **Invalid email (no TLD) returns wrong error** — `user@amalitech` passed validation and hit the service, returning "Invalid credentials". Added strict `@Email` regexp requiring a proper TLD.

2. **Name whitespace stored as-is** — Padded names now trimmed via `.trim()` in `AuthService` before persisting.

3. **Name accepts special characters and digits** — `@Pattern` added to `RegisterRequest` rejecting anything other than letters, spaces, hyphens, and apostrophes.

4. **Wrong HTTP method returns 401 instead of 405** — Added `HttpRequestMethodNotSupportedException` handler (→ 405) and added `/error` to `permitAll()`.

5. **Registration response missing user ID** — `userRepository.save()` return value now captured as `savedUser` to populate the `id` in the response.

6. **Password leak prevention** — `@JsonIgnore` added to `User.password` as defence-in-depth.

## Testing
- `mvn clean test` → BUILD SUCCESS
- All pre-commit hooks passed