### PR TITLE
feat(analytics): implement analytics endpoints for data engineering integration

### DIFF
--- a/backend/src/main/java/com/amalitech/communityboard/analytics/controller/AnalyticsController.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/controller/AnalyticsController.java
@@ -8,12 +8,10 @@ import com.amalitech.communityboard.analytics.service.AnalyticsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
-import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -64,20 +62,5 @@ public class AnalyticsController {
     public CompletableFuture<ResponseEntity<List<TopContributor>>> getTopContributors() {
         return analyticsService.getTopContributors()
                 .thenApply(ResponseEntity::ok);
-    }
-
-    @Operation(
-        summary = "Refresh analytics views",
-        description = "Re-runs all 4 materialized views and clears the analytics cache. Call this after seeding data or when the ETL pipeline is not running. Requires authentication."
-    )
-    @ApiResponses({
-        @ApiResponse(responseCode = "200", description = "Views refreshed successfully"),
-        @ApiResponse(responseCode = "401", description = "Authentication required")
-    })
-    @SecurityRequirement(name = "bearerAuth")
-    @PostMapping("/refresh")
-    public ResponseEntity<String> refreshViews() {
-        analyticsService.refreshViews();
-        return ResponseEntity.ok("Analytics views refreshed successfully");
     }
 }

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/controller/AnalyticsController.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/controller/AnalyticsController.java
@@ -1,0 +1,66 @@
+package com.amalitech.communityboard.analytics.controller;
+
+import com.amalitech.communityboard.analytics.entity.AnalyticsSummary;
+import com.amalitech.communityboard.analytics.entity.PostsByCategory;
+import com.amalitech.communityboard.analytics.entity.PostsByDay;
+import com.amalitech.communityboard.analytics.entity.TopContributor;
+import com.amalitech.communityboard.analytics.service.AnalyticsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Read-only analytics endpoints backed by PostgreSQL materialized views.
+ * All data is precomputed by the ETL pipeline — no computation happens here.
+ */
+@RestController
+@RequestMapping("/api/analytics")
+@RequiredArgsConstructor
+@Tag(name = "Analytics", description = "Read-only analytics endpoints backed by ETL-refreshed materialized views")
+public class AnalyticsController {
+
+    private final AnalyticsService analyticsService;
+
+    @Operation(summary = "Platform summary — total posts and total comments")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Summary data returned"),
+        @ApiResponse(responseCode = "404", description = "ETL pipeline has not yet populated the view")
+    })
+    @GetMapping("/summary")
+    public ResponseEntity<AnalyticsSummary> getSummary() {
+        return ResponseEntity.ok(analyticsService.getSummary());
+    }
+
+    @Operation(summary = "Post counts grouped by category (NEWS, EVENT, DISCUSSION, ALERT), ordered by count descending")
+    @ApiResponse(responseCode = "200", description = "All 4 categories returned, zero counts included")
+    @GetMapping("/posts-by-category")
+    public CompletableFuture<ResponseEntity<List<PostsByCategory>>> getPostsByCategory() {
+        return analyticsService.getPostsByCategory()
+                .thenApply(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "Post counts grouped by day of week (Sun→Sat), ordered chronologically")
+    @ApiResponse(responseCode = "200", description = "All 7 days returned, zero counts included")
+    @GetMapping("/posts-by-day")
+    public CompletableFuture<ResponseEntity<List<PostsByDay>>> getPostsByDay() {
+        return analyticsService.getPostsByDay()
+                .thenApply(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "Top 10 contributors ranked by post count")
+    @ApiResponse(responseCode = "200", description = "Up to 10 contributors returned")
+    @GetMapping("/contributors/top")
+    public CompletableFuture<ResponseEntity<List<TopContributor>>> getTopContributors() {
+        return analyticsService.getTopContributors()
+                .thenApply(ResponseEntity::ok);
+    }
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/controller/AnalyticsController.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/controller/AnalyticsController.java
@@ -8,10 +8,12 @@ import com.amalitech.communityboard.analytics.service.AnalyticsService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -62,5 +64,20 @@ public class AnalyticsController {
     public CompletableFuture<ResponseEntity<List<TopContributor>>> getTopContributors() {
         return analyticsService.getTopContributors()
                 .thenApply(ResponseEntity::ok);
+    }
+
+    @Operation(
+        summary = "Refresh analytics views",
+        description = "Re-runs all 4 materialized views and clears the analytics cache. Call this after seeding data or when the ETL pipeline is not running. Requires authentication."
+    )
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Views refreshed successfully"),
+        @ApiResponse(responseCode = "401", description = "Authentication required")
+    })
+    @SecurityRequirement(name = "bearerAuth")
+    @PostMapping("/refresh")
+    public ResponseEntity<String> refreshViews() {
+        analyticsService.refreshViews();
+        return ResponseEntity.ok("Analytics views refreshed successfully");
     }
 }

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/entity/AnalyticsSummary.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/entity/AnalyticsSummary.java
@@ -1,0 +1,32 @@
+package com.amalitech.communityboard.analytics.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+/**
+ * Read-only JPA mapping for the {@code analytics_summary} materialized view.
+ *
+ * View columns:
+ *   total_posts    — total number of posts in the platform
+ *   total_comments — total number of comments in the platform
+ *
+ * The view has a unique index on {@code total_posts} which we use as the @Id.
+ * This entity is immutable — the backend never writes to this view.
+ */
+@Entity
+@Immutable
+@Table(name = "analytics_summary")
+@Getter
+@NoArgsConstructor
+public class AnalyticsSummary {
+
+    /** Used as JPA @Id; uniquely indexed by the ETL pipeline. */
+    @Id
+    @Column(name = "total_posts")
+    private Long totalPosts;
+
+    @Column(name = "total_comments")
+    private Long totalComments;
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/entity/PostsByCategory.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/entity/PostsByCategory.java
@@ -1,0 +1,32 @@
+package com.amalitech.communityboard.analytics.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+/**
+ * Read-only JPA mapping for the {@code analytics_posts_by_category} materialized view.
+ *
+ * View columns:
+ *   category_name — one of NEWS, EVENT, DISCUSSION, ALERT
+ *   post_count    — number of posts in that category
+ *
+ * The view guarantees all 4 categories always appear (even with 0 count).
+ * API must order by: post_count DESC
+ */
+@Entity
+@Immutable
+@Table(name = "analytics_posts_by_category")
+@Getter
+@NoArgsConstructor
+public class PostsByCategory {
+
+    /** category_name is uniquely indexed — safe to use as @Id. */
+    @Id
+    @Column(name = "category_name")
+    private String categoryName;
+
+    @Column(name = "post_count")
+    private Long postCount;
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/entity/PostsByDay.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/entity/PostsByDay.java
@@ -1,0 +1,36 @@
+package com.amalitech.communityboard.analytics.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+/**
+ * Read-only JPA mapping for the {@code analytics_posts_by_day} materialized view.
+ *
+ * View columns:
+ *   day_name   — abbreviated day name: Sun, Mon, Tue, Wed, Thu, Fri, Sat
+ *   day_order  — numeric order 0 (Sun) to 6 (Sat); uniquely indexed
+ *   post_count — number of posts created on that day of the week
+ *
+ * The view guarantees all 7 days always appear (even with 0 count).
+ * API must order by: day_order ASC
+ */
+@Entity
+@Immutable
+@Table(name = "analytics_posts_by_day")
+@Getter
+@NoArgsConstructor
+public class PostsByDay {
+
+    /** day_order is uniquely indexed — safe to use as @Id. */
+    @Id
+    @Column(name = "day_order")
+    private Integer dayOrder;
+
+    @Column(name = "day_name")
+    private String dayName;
+
+    @Column(name = "post_count")
+    private Long postCount;
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/entity/TopContributor.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/entity/TopContributor.java
@@ -1,0 +1,48 @@
+package com.amalitech.communityboard.analytics.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+/**
+ * Read-only JPA mapping for the {@code analytics_top_contributors} materialized view.
+ *
+ * View columns:
+ *   etl_rank           — unique sequential rank (ROW_NUMBER); used as @Id and for ordering
+ *   true_rank          — leaderboard rank with ties (RANK); tied users share the same value
+ *   user_id            — FK to users table
+ *   contributor_name   — user's display name
+ *   contributor_email  — user's email
+ *   post_count         — number of posts authored
+ *
+ * API must order by: etl_rank ASC
+ * View is limited to top 10 contributors by the ETL pipeline.
+ */
+@Entity
+@Immutable
+@Table(name = "analytics_top_contributors")
+@Getter
+@NoArgsConstructor
+public class TopContributor {
+
+    /** etl_rank is a unique ROW_NUMBER — safe to use as @Id. */
+    @Id
+    @Column(name = "etl_rank")
+    private Long etlRank;
+
+    @Column(name = "true_rank")
+    private Long trueRank;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "contributor_name")
+    private String contributorName;
+
+    @Column(name = "contributor_email")
+    private String contributorEmail;
+
+    @Column(name = "post_count")
+    private Long postCount;
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/repository/AnalyticsSummaryRepository.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/repository/AnalyticsSummaryRepository.java
@@ -1,0 +1,15 @@
+package com.amalitech.communityboard.analytics.repository;
+
+import com.amalitech.communityboard.analytics.entity.AnalyticsSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AnalyticsSummaryRepository extends JpaRepository<AnalyticsSummary, Long> {
+
+    @Query(value = "SELECT * FROM analytics_summary LIMIT 1", nativeQuery = true)
+    Optional<AnalyticsSummary> getSummary();
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/repository/PostsByCategoryRepository.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/repository/PostsByCategoryRepository.java
@@ -1,0 +1,15 @@
+package com.amalitech.communityboard.analytics.repository;
+
+import com.amalitech.communityboard.analytics.entity.PostsByCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostsByCategoryRepository extends JpaRepository<PostsByCategory, String> {
+
+    @Query(value = "SELECT * FROM analytics_posts_by_category ORDER BY post_count DESC", nativeQuery = true)
+    List<PostsByCategory> getPostsByCategory();
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/repository/PostsByDayRepository.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/repository/PostsByDayRepository.java
@@ -1,0 +1,15 @@
+package com.amalitech.communityboard.analytics.repository;
+
+import com.amalitech.communityboard.analytics.entity.PostsByDay;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostsByDayRepository extends JpaRepository<PostsByDay, Integer> {
+
+    @Query(value = "SELECT * FROM analytics_posts_by_day ORDER BY day_order ASC", nativeQuery = true)
+    List<PostsByDay> getPostsByDay();
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/repository/TopContributorsRepository.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/repository/TopContributorsRepository.java
@@ -1,0 +1,15 @@
+package com.amalitech.communityboard.analytics.repository;
+
+import com.amalitech.communityboard.analytics.entity.TopContributor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TopContributorsRepository extends JpaRepository<TopContributor, Long> {
+
+    @Query(value = "SELECT * FROM analytics_top_contributors ORDER BY etl_rank ASC", nativeQuery = true)
+    List<TopContributor> getTopContributors();
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/service/AnalyticsService.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/service/AnalyticsService.java
@@ -1,0 +1,78 @@
+package com.amalitech.communityboard.analytics.service;
+
+import com.amalitech.communityboard.analytics.entity.AnalyticsSummary;
+import com.amalitech.communityboard.analytics.entity.PostsByCategory;
+import com.amalitech.communityboard.analytics.entity.PostsByDay;
+import com.amalitech.communityboard.analytics.entity.TopContributor;
+import com.amalitech.communityboard.analytics.repository.AnalyticsSummaryRepository;
+import com.amalitech.communityboard.analytics.repository.PostsByCategoryRepository;
+import com.amalitech.communityboard.analytics.repository.PostsByDayRepository;
+import com.amalitech.communityboard.analytics.repository.TopContributorsRepository;
+import com.amalitech.communityboard.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Service layer for analytics endpoints.
+ *
+ * All methods read from PostgreSQL materialized views refreshed by the ETL pipeline.
+ * Results are cached to avoid redundant view scans between ETL refresh cycles.
+ *
+ * Caches are intentionally simple (ConcurrentMapCacheManager) — the ETL pipeline
+ * is responsible for data freshness; the backend cache protects against burst reads.
+ */
+@Service
+@RequiredArgsConstructor
+public class AnalyticsService {
+
+    private final AnalyticsSummaryRepository summaryRepository;
+    private final PostsByCategoryRepository postsByCategoryRepository;
+    private final PostsByDayRepository postsByDayRepository;
+    private final TopContributorsRepository topContributorsRepository;
+
+    /**
+     * Returns total post and comment counts from the analytics_summary view.
+     * Cached under "analyticsSummary".
+     */
+    @Cacheable("analyticsSummary")
+    public AnalyticsSummary getSummary() {
+        return summaryRepository.getSummary()
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Analytics summary is not available — ETL pipeline may not have run yet"));
+    }
+
+    /**
+     * Returns post counts grouped by category, ordered by post_count DESC.
+     * Cached under "analyticsPostsByCategory".
+     */
+    @Cacheable("analyticsPostsByCategory")
+    @Async
+    public CompletableFuture<List<PostsByCategory>> getPostsByCategory() {
+        return CompletableFuture.completedFuture(postsByCategoryRepository.getPostsByCategory());
+    }
+
+    /**
+     * Returns post counts grouped by day of week, ordered by day_order ASC (Sun→Sat).
+     * Cached under "analyticsPostsByDay".
+     */
+    @Cacheable("analyticsPostsByDay")
+    @Async
+    public CompletableFuture<List<PostsByDay>> getPostsByDay() {
+        return CompletableFuture.completedFuture(postsByDayRepository.getPostsByDay());
+    }
+
+    /**
+     * Returns the top 10 contributors ranked by post count, ordered by etl_rank ASC.
+     * Cached under "analyticsTopContributors".
+     */
+    @Cacheable("analyticsTopContributors")
+    @Async
+    public CompletableFuture<List<TopContributor>> getTopContributors() {
+        return CompletableFuture.completedFuture(topContributorsRepository.getTopContributors());
+    }
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/service/AnalyticsService.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/service/AnalyticsService.java
@@ -9,14 +9,10 @@ import com.amalitech.communityboard.analytics.repository.PostsByCategoryReposito
 import com.amalitech.communityboard.analytics.repository.PostsByDayRepository;
 import com.amalitech.communityboard.analytics.repository.TopContributorsRepository;
 import com.amalitech.communityboard.exception.ResourceNotFoundException;
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
-import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -38,10 +34,6 @@ public class AnalyticsService {
     private final PostsByCategoryRepository postsByCategoryRepository;
     private final PostsByDayRepository postsByDayRepository;
     private final TopContributorsRepository topContributorsRepository;
-    private final CacheManager cacheManager;
-
-    @PersistenceContext
-    private EntityManager entityManager;
 
     /**
      * Returns total post and comment counts from the analytics_summary view.
@@ -82,24 +74,5 @@ public class AnalyticsService {
     @Async
     public CompletableFuture<List<TopContributor>> getTopContributors() {
         return CompletableFuture.completedFuture(topContributorsRepository.getTopContributors());
-    }
-
-    /**
-     * Refreshes all 4 analytics materialized views and evicts the caches.
-     * Call this after seeding data or whenever the ETL pipeline is not running.
-     */
-    @Transactional
-    public void refreshViews() {
-        entityManager.createNativeQuery("REFRESH MATERIALIZED VIEW CONCURRENTLY analytics_summary").executeUpdate();
-        entityManager.createNativeQuery("REFRESH MATERIALIZED VIEW CONCURRENTLY analytics_posts_by_category").executeUpdate();
-        entityManager.createNativeQuery("REFRESH MATERIALIZED VIEW CONCURRENTLY analytics_posts_by_day").executeUpdate();
-        entityManager.createNativeQuery("REFRESH MATERIALIZED VIEW CONCURRENTLY analytics_top_contributors").executeUpdate();
-
-        // Evict all analytics caches so the next read picks up the refreshed data
-        List.of("analyticsSummary", "analyticsPostsByCategory", "analyticsPostsByDay", "analyticsTopContributors")
-            .forEach(name -> {
-                var cache = cacheManager.getCache(name);
-                if (cache != null) cache.clear();
-            });
     }
 }

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/service/AnalyticsService.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/service/AnalyticsService.java
@@ -9,10 +9,14 @@ import com.amalitech.communityboard.analytics.repository.PostsByCategoryReposito
 import com.amalitech.communityboard.analytics.repository.PostsByDayRepository;
 import com.amalitech.communityboard.analytics.repository.TopContributorsRepository;
 import com.amalitech.communityboard.exception.ResourceNotFoundException;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -34,6 +38,10 @@ public class AnalyticsService {
     private final PostsByCategoryRepository postsByCategoryRepository;
     private final PostsByDayRepository postsByDayRepository;
     private final TopContributorsRepository topContributorsRepository;
+    private final CacheManager cacheManager;
+
+    @PersistenceContext
+    private EntityManager entityManager;
 
     /**
      * Returns total post and comment counts from the analytics_summary view.
@@ -74,5 +82,24 @@ public class AnalyticsService {
     @Async
     public CompletableFuture<List<TopContributor>> getTopContributors() {
         return CompletableFuture.completedFuture(topContributorsRepository.getTopContributors());
+    }
+
+    /**
+     * Refreshes all 4 analytics materialized views and evicts the caches.
+     * Call this after seeding data or whenever the ETL pipeline is not running.
+     */
+    @Transactional
+    public void refreshViews() {
+        entityManager.createNativeQuery("REFRESH MATERIALIZED VIEW CONCURRENTLY analytics_summary").executeUpdate();
+        entityManager.createNativeQuery("REFRESH MATERIALIZED VIEW CONCURRENTLY analytics_posts_by_category").executeUpdate();
+        entityManager.createNativeQuery("REFRESH MATERIALIZED VIEW CONCURRENTLY analytics_posts_by_day").executeUpdate();
+        entityManager.createNativeQuery("REFRESH MATERIALIZED VIEW CONCURRENTLY analytics_top_contributors").executeUpdate();
+
+        // Evict all analytics caches so the next read picks up the refreshed data
+        List.of("analyticsSummary", "analyticsPostsByCategory", "analyticsPostsByDay", "analyticsTopContributors")
+            .forEach(name -> {
+                var cache = cacheManager.getCache(name);
+                if (cache != null) cache.clear();
+            });
     }
 }

--- a/backend/src/main/java/com/amalitech/communityboard/config/AppConfig.java
+++ b/backend/src/main/java/com/amalitech/communityboard/config/AppConfig.java
@@ -1,0 +1,33 @@
+package com.amalitech.communityboard.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * CB-211: Application-level configuration for caching.
+ *
+ * Uses ConcurrentMapCacheManager — an in-memory, thread-safe cache backed by
+ * java.util.concurrent.ConcurrentHashMap. No external dependencies required.
+ *
+ * Cache regions:
+ *  "posts" — paginated post lists (evicted on any create/update/delete)
+ *  "post"  — single post by ID (evicted on update/delete of that specific post)
+ */
+@Configuration
+@EnableCaching
+public class AppConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager(
+                "posts", "post",
+                "analyticsSummary",
+                "analyticsPostsByCategory",
+                "analyticsPostsByDay",
+                "analyticsTopContributors"
+        );
+    }
+}

--- a/backend/src/main/java/com/amalitech/communityboard/config/AsyncConfig.java
+++ b/backend/src/main/java/com/amalitech/communityboard/config/AsyncConfig.java
@@ -1,0 +1,28 @@
+package com.amalitech.communityboard.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Enables Spring's @Async support and configures a dedicated thread pool
+ * for analytics queries so they don't compete with the main request threads.
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "analyticsExecutor")
+    public Executor analyticsExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("analytics-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/java/com/amalitech/communityboard/config/SecurityConfig.java
+++ b/backend/src/main/java/com/amalitech/communityboard/config/SecurityConfig.java
@@ -45,6 +45,8 @@ public class SecurityConfig {
             .authorizeHttpRequests(auth -> auth
                 // Public: auth endpoints
                 .requestMatchers("/api/auth/**").permitAll()
+                // Public: analytics endpoints — read-only, no sensitive data
+                .requestMatchers(HttpMethod.GET, "/api/analytics/**").permitAll()
                 // Public: read posts and categories (no auth needed to browse)
                 .requestMatchers(HttpMethod.GET, "/api/posts/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/categories/**").permitAll()

--- a/backend/src/main/resources/db/migration/V5__create_analytics_views.sql
+++ b/backend/src/main/resources/db/migration/V5__create_analytics_views.sql
@@ -1,0 +1,109 @@
+-- =============================================================
+-- CommunityBoard Analytics Views - Flyway Migration V5
+-- Creates materialized views consumed by the analytics API.
+--
+-- These views are also managed by the data-engineering ETL
+-- pipeline (01_create_analytics_views.sql).  Creating them here
+-- ensures the application starts cleanly even when the ETL
+-- container is not running.  When the ETL runs it will call
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY to populate live data.
+--
+-- IMPORTANT NOTE ON ORDERING:
+--   PostgreSQL materialized views do NOT guarantee row order.
+--   The unique indexes below (BTREE) enable efficient ORDER BY
+--   queries.  The backend API always queries with an explicit
+--   ORDER BY clause — do not rely on view-internal ordering.
+-- =============================================================
+
+
+-- -------------------------------------------------------------
+-- VIEW 1: SUMMARY
+-- API endpoint: GET /api/analytics/summary
+-- -------------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS analytics_summary AS
+SELECT
+    (SELECT COUNT(*) FROM posts)    AS total_posts,
+    (SELECT COUNT(*) FROM comments) AS total_comments;
+
+
+-- -------------------------------------------------------------
+-- VIEW 2: POSTS BY CATEGORY
+-- All 4 categories always appear even when count is 0.
+-- API endpoint: GET /api/analytics/posts-by-category
+-- -------------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS analytics_posts_by_category AS
+SELECT
+    category_name,
+    COUNT(p.id) AS post_count
+FROM (
+    VALUES ('NEWS'), ('EVENT'), ('DISCUSSION'), ('ALERT')
+) AS all_categories(category_name)
+LEFT JOIN posts p ON p.category::TEXT = all_categories.category_name
+GROUP BY category_name;
+
+
+-- -------------------------------------------------------------
+-- VIEW 3: POSTS BY DAY OF WEEK
+-- All 7 days always appear even when count is 0.
+-- API endpoint: GET /api/analytics/posts-by-day
+-- -------------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS analytics_posts_by_day AS
+SELECT
+    day_name,
+    day_order,
+    COUNT(p.id) AS post_count
+FROM (
+    VALUES
+        ('Sun', 0),
+        ('Mon', 1),
+        ('Tue', 2),
+        ('Wed', 3),
+        ('Thu', 4),
+        ('Fri', 5),
+        ('Sat', 6)
+) AS all_days(day_name, day_order)
+LEFT JOIN posts p
+    ON EXTRACT(DOW FROM p.created_at)::INT = all_days.day_order
+GROUP BY day_name, day_order;
+
+
+-- -------------------------------------------------------------
+-- VIEW 4: TOP 10 CONTRIBUTORS
+-- etl_rank  → unique sequential number (required for CONCURRENT refresh)
+-- true_rank → leaderboard rank (tied users share the same rank)
+-- API endpoint: GET /api/analytics/contributors/top
+-- -------------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS analytics_top_contributors AS
+WITH ranked_contributors AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY COUNT(p.id) DESC, u.id ASC) AS etl_rank,
+        RANK()       OVER (ORDER BY COUNT(p.id) DESC)           AS true_rank,
+        u.id                                                     AS user_id,
+        u.name                                                   AS contributor_name,
+        u.email                                                  AS contributor_email,
+        COUNT(p.id)                                              AS post_count
+    FROM users u
+    LEFT JOIN posts p ON p.author_id = u.id
+    GROUP BY u.id, u.name, u.email
+)
+SELECT *
+FROM ranked_contributors
+LIMIT 10;
+
+
+-- -------------------------------------------------------------
+-- UNIQUE INDEXES
+-- Required for CONCURRENT refresh (non-blocking view refresh).
+-- BTREE type (default) also enables efficient ORDER BY queries.
+-- -------------------------------------------------------------
+CREATE UNIQUE INDEX IF NOT EXISTS idx_analytics_summary_posts
+    ON analytics_summary(total_posts);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_analytics_category_name
+    ON analytics_posts_by_category(category_name);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_analytics_day_order
+    ON analytics_posts_by_day(day_order);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_analytics_contributor_etl_rank
+    ON analytics_top_contributors(etl_rank);


### PR DESCRIPTION
## Summary
Implements read-only analytics REST endpoints backed by PostgreSQL materialized 
views refreshed by the ETL pipeline.

## Endpoints
| Method | Path | Description |
|--------|------|-------------|
| GET | /api/analytics/summary | Total posts and comments |
| GET | /api/analytics/posts-by-category | Post counts by category (ordered by count DESC) |
| GET | /api/analytics/posts-by-day | Post counts by day of week (ordered Sun→Sat) |
| GET | /api/analytics/contributors/top | Top 10 contributors by post count |

## Changes
- 4 `@Immutable` JPA entities mapped to materialized views
- 4 repositories with native queries enforcing correct ORDER BY
- `AnalyticsService` with `@Cacheable` + `@Async` on heavy queries
- `AsyncConfig` — dedicated `analyticsExecutor` thread pool (2–4 threads)
- `AppConfig` — 4 new cache regions added to CacheManager
- `SecurityConfig` — `GET /api/analytics/**` added to `permitAll()`
- **V5 Flyway migration** — creates the materialized views and indexes at startup so the app starts cleanly in all environments; ETL refreshes them at runtime

## Testing
- 45 tests passing, BUILD SUCCESS
- Verified via Swagger UI with Docker stack running