### PR TITLE
fix(frontend): remove nginx backend upstream proxy that crashes ECS c…

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -1,15 +1,11 @@
 server {
     listen 80;
-    location /api/ {
-        proxy_pass http://backend:8080/api/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
     location / {
         root /usr/share/nginx/html;
         index index.html;
         try_files $uri $uri/ /index.html;
     }
+    # /api/* requests are routed by the ALB directly to the backend target group.
+    # nginx does not proxy to the backend — the browser makes the call and the
+    # ALB handles routing, so no upstream hostname needs to be resolved here.
 }


### PR DESCRIPTION
…ontainer

Re-introduces the fix from ab16ea1 (#71) which was accidentally overwritten by the analytics PR ec97706 (#83). The 'backend' hostname is only resolvable in Docker Compose — on ECS nginx crashes at startup with 'host not found in upstream'. API calls are routed by the ALB, not nginx.

## Description
<!-- Brief description of changes -->

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test coverage improvement

## Related Ticket
Closes #TICKET_NUMBER

## Changes Made
<!-- List key changes -->
-
-
-

## Testing
<!-- Describe testing performed -->

**Test Coverage:**
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed

**Test Results:**
```
Backend: X% coverage
Frontend: X% coverage
```

## Screenshots (if applicable)
<!-- Add screenshots for UI changes -->

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated
- [ ] Tests added/updated and passing
- [ ] No new warnings
- [ ] Dependent changes merged
- [ ] Branch is up to date with base branch
- [ ] No merge conflicts

## Deployment Notes
<!-- Any special deployment considerations -->

## Rollback Plan
<!-- How to rollback if issues occur -->

## Additional Context
<!-- Any other relevant information -->
