### PR TITLE
feat(analytics): restore analytics feature and integrate ETL endpoints [CB-101]

### DIFF
--- a/backend/src/main/java/com/amalitech/communityboard/analytics/controller/AnalyticsController.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/controller/AnalyticsController.java
@@ -1,0 +1,66 @@
+package com.amalitech.communityboard.analytics.controller;
+
+import com.amalitech.communityboard.analytics.entity.AnalyticsSummary;
+import com.amalitech.communityboard.analytics.entity.PostsByCategory;
+import com.amalitech.communityboard.analytics.entity.PostsByDay;
+import com.amalitech.communityboard.analytics.entity.TopContributor;
+import com.amalitech.communityboard.analytics.service.AnalyticsService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Read-only analytics endpoints backed by PostgreSQL materialized views.
+ * All data is precomputed by the ETL pipeline — no computation happens here.
+ */
+@RestController
+@RequestMapping("/api/analytics")
+@RequiredArgsConstructor
+@Tag(name = "Analytics", description = "Read-only analytics endpoints backed by ETL-refreshed materialized views")
+public class AnalyticsController {
+
+    private final AnalyticsService analyticsService;
+
+    @Operation(summary = "Platform summary — total posts and total comments")
+    @ApiResponses({
+        @ApiResponse(responseCode = "200", description = "Summary data returned"),
+        @ApiResponse(responseCode = "404", description = "ETL pipeline has not yet populated the view")
+    })
+    @GetMapping("/summary")
+    public ResponseEntity<AnalyticsSummary> getSummary() {
+        return ResponseEntity.ok(analyticsService.getSummary());
+    }
+
+    @Operation(summary = "Post counts grouped by category (NEWS, EVENT, DISCUSSION, ALERT), ordered by count descending")
+    @ApiResponse(responseCode = "200", description = "All 4 categories returned, zero counts included")
+    @GetMapping("/posts-by-category")
+    public CompletableFuture<ResponseEntity<List<PostsByCategory>>> getPostsByCategory() {
+        return analyticsService.getPostsByCategory()
+                .thenApply(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "Post counts grouped by day of week (Sun→Sat), ordered chronologically")
+    @ApiResponse(responseCode = "200", description = "All 7 days returned, zero counts included")
+    @GetMapping("/posts-by-day")
+    public CompletableFuture<ResponseEntity<List<PostsByDay>>> getPostsByDay() {
+        return analyticsService.getPostsByDay()
+                .thenApply(ResponseEntity::ok);
+    }
+
+    @Operation(summary = "Top 10 contributors ranked by post count")
+    @ApiResponse(responseCode = "200", description = "Up to 10 contributors returned")
+    @GetMapping("/contributors/top")
+    public CompletableFuture<ResponseEntity<List<TopContributor>>> getTopContributors() {
+        return analyticsService.getTopContributors()
+                .thenApply(ResponseEntity::ok);
+    }
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/entity/AnalyticsSummary.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/entity/AnalyticsSummary.java
@@ -1,0 +1,32 @@
+package com.amalitech.communityboard.analytics.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+/**
+ * Read-only JPA mapping for the {@code analytics_summary} materialized view.
+ *
+ * View columns:
+ *   total_posts    — total number of posts in the platform
+ *   total_comments — total number of comments in the platform
+ *
+ * The view has a unique index on {@code total_posts} which we use as the @Id.
+ * This entity is immutable — the backend never writes to this view.
+ */
+@Entity
+@Immutable
+@Table(name = "analytics_summary")
+@Getter
+@NoArgsConstructor
+public class AnalyticsSummary {
+
+    /** Used as JPA @Id; uniquely indexed by the ETL pipeline. */
+    @Id
+    @Column(name = "total_posts")
+    private Long totalPosts;
+
+    @Column(name = "total_comments")
+    private Long totalComments;
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/entity/PostsByCategory.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/entity/PostsByCategory.java
@@ -1,0 +1,32 @@
+package com.amalitech.communityboard.analytics.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+/**
+ * Read-only JPA mapping for the {@code analytics_posts_by_category} materialized view.
+ *
+ * View columns:
+ *   category_name — one of NEWS, EVENT, DISCUSSION, ALERT
+ *   post_count    — number of posts in that category
+ *
+ * The view guarantees all 4 categories always appear (even with 0 count).
+ * API must order by: post_count DESC
+ */
+@Entity
+@Immutable
+@Table(name = "analytics_posts_by_category")
+@Getter
+@NoArgsConstructor
+public class PostsByCategory {
+
+    /** category_name is uniquely indexed — safe to use as @Id. */
+    @Id
+    @Column(name = "category_name")
+    private String categoryName;
+
+    @Column(name = "post_count")
+    private Long postCount;
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/entity/PostsByDay.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/entity/PostsByDay.java
@@ -1,0 +1,36 @@
+package com.amalitech.communityboard.analytics.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+/**
+ * Read-only JPA mapping for the {@code analytics_posts_by_day} materialized view.
+ *
+ * View columns:
+ *   day_name   — abbreviated day name: Sun, Mon, Tue, Wed, Thu, Fri, Sat
+ *   day_order  — numeric order 0 (Sun) to 6 (Sat); uniquely indexed
+ *   post_count — number of posts created on that day of the week
+ *
+ * The view guarantees all 7 days always appear (even with 0 count).
+ * API must order by: day_order ASC
+ */
+@Entity
+@Immutable
+@Table(name = "analytics_posts_by_day")
+@Getter
+@NoArgsConstructor
+public class PostsByDay {
+
+    /** day_order is uniquely indexed — safe to use as @Id. */
+    @Id
+    @Column(name = "day_order")
+    private Integer dayOrder;
+
+    @Column(name = "day_name")
+    private String dayName;
+
+    @Column(name = "post_count")
+    private Long postCount;
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/entity/TopContributor.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/entity/TopContributor.java
@@ -1,0 +1,48 @@
+package com.amalitech.communityboard.analytics.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Immutable;
+
+/**
+ * Read-only JPA mapping for the {@code analytics_top_contributors} materialized view.
+ *
+ * View columns:
+ *   etl_rank           — unique sequential rank (ROW_NUMBER); used as @Id and for ordering
+ *   true_rank          — leaderboard rank with ties (RANK); tied users share the same value
+ *   user_id            — FK to users table
+ *   contributor_name   — user's display name
+ *   contributor_email  — user's email
+ *   post_count         — number of posts authored
+ *
+ * API must order by: etl_rank ASC
+ * View is limited to top 10 contributors by the ETL pipeline.
+ */
+@Entity
+@Immutable
+@Table(name = "analytics_top_contributors")
+@Getter
+@NoArgsConstructor
+public class TopContributor {
+
+    /** etl_rank is a unique ROW_NUMBER — safe to use as @Id. */
+    @Id
+    @Column(name = "etl_rank")
+    private Long etlRank;
+
+    @Column(name = "true_rank")
+    private Long trueRank;
+
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "contributor_name")
+    private String contributorName;
+
+    @Column(name = "contributor_email")
+    private String contributorEmail;
+
+    @Column(name = "post_count")
+    private Long postCount;
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/repository/AnalyticsSummaryRepository.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/repository/AnalyticsSummaryRepository.java
@@ -1,0 +1,15 @@
+package com.amalitech.communityboard.analytics.repository;
+
+import com.amalitech.communityboard.analytics.entity.AnalyticsSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AnalyticsSummaryRepository extends JpaRepository<AnalyticsSummary, Long> {
+
+    @Query(value = "SELECT * FROM analytics_summary LIMIT 1", nativeQuery = true)
+    Optional<AnalyticsSummary> getSummary();
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/repository/PostsByCategoryRepository.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/repository/PostsByCategoryRepository.java
@@ -1,0 +1,15 @@
+package com.amalitech.communityboard.analytics.repository;
+
+import com.amalitech.communityboard.analytics.entity.PostsByCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostsByCategoryRepository extends JpaRepository<PostsByCategory, String> {
+
+    @Query(value = "SELECT * FROM analytics_posts_by_category ORDER BY post_count DESC", nativeQuery = true)
+    List<PostsByCategory> getPostsByCategory();
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/repository/PostsByDayRepository.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/repository/PostsByDayRepository.java
@@ -1,0 +1,15 @@
+package com.amalitech.communityboard.analytics.repository;
+
+import com.amalitech.communityboard.analytics.entity.PostsByDay;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PostsByDayRepository extends JpaRepository<PostsByDay, Integer> {
+
+    @Query(value = "SELECT * FROM analytics_posts_by_day ORDER BY day_order ASC", nativeQuery = true)
+    List<PostsByDay> getPostsByDay();
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/repository/TopContributorsRepository.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/repository/TopContributorsRepository.java
@@ -1,0 +1,15 @@
+package com.amalitech.communityboard.analytics.repository;
+
+import com.amalitech.communityboard.analytics.entity.TopContributor;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TopContributorsRepository extends JpaRepository<TopContributor, Long> {
+
+    @Query(value = "SELECT * FROM analytics_top_contributors ORDER BY etl_rank ASC", nativeQuery = true)
+    List<TopContributor> getTopContributors();
+}

--- a/backend/src/main/java/com/amalitech/communityboard/analytics/service/AnalyticsService.java
+++ b/backend/src/main/java/com/amalitech/communityboard/analytics/service/AnalyticsService.java
@@ -1,0 +1,78 @@
+package com.amalitech.communityboard.analytics.service;
+
+import com.amalitech.communityboard.analytics.entity.AnalyticsSummary;
+import com.amalitech.communityboard.analytics.entity.PostsByCategory;
+import com.amalitech.communityboard.analytics.entity.PostsByDay;
+import com.amalitech.communityboard.analytics.entity.TopContributor;
+import com.amalitech.communityboard.analytics.repository.AnalyticsSummaryRepository;
+import com.amalitech.communityboard.analytics.repository.PostsByCategoryRepository;
+import com.amalitech.communityboard.analytics.repository.PostsByDayRepository;
+import com.amalitech.communityboard.analytics.repository.TopContributorsRepository;
+import com.amalitech.communityboard.exception.ResourceNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+/**
+ * Service layer for analytics endpoints.
+ *
+ * All methods read from PostgreSQL materialized views refreshed by the ETL pipeline.
+ * Results are cached to avoid redundant view scans between ETL refresh cycles.
+ *
+ * Caches are intentionally simple (ConcurrentMapCacheManager) — the ETL pipeline
+ * is responsible for data freshness; the backend cache protects against burst reads.
+ */
+@Service
+@RequiredArgsConstructor
+public class AnalyticsService {
+
+    private final AnalyticsSummaryRepository summaryRepository;
+    private final PostsByCategoryRepository postsByCategoryRepository;
+    private final PostsByDayRepository postsByDayRepository;
+    private final TopContributorsRepository topContributorsRepository;
+
+    /**
+     * Returns total post and comment counts from the analytics_summary view.
+     * Cached under "analyticsSummary".
+     */
+    @Cacheable("analyticsSummary")
+    public AnalyticsSummary getSummary() {
+        return summaryRepository.getSummary()
+                .orElseThrow(() -> new ResourceNotFoundException(
+                        "Analytics summary is not available — ETL pipeline may not have run yet"));
+    }
+
+    /**
+     * Returns post counts grouped by category, ordered by post_count DESC.
+     * Cached under "analyticsPostsByCategory".
+     */
+    @Cacheable("analyticsPostsByCategory")
+    @Async
+    public CompletableFuture<List<PostsByCategory>> getPostsByCategory() {
+        return CompletableFuture.completedFuture(postsByCategoryRepository.getPostsByCategory());
+    }
+
+    /**
+     * Returns post counts grouped by day of week, ordered by day_order ASC (Sun→Sat).
+     * Cached under "analyticsPostsByDay".
+     */
+    @Cacheable("analyticsPostsByDay")
+    @Async
+    public CompletableFuture<List<PostsByDay>> getPostsByDay() {
+        return CompletableFuture.completedFuture(postsByDayRepository.getPostsByDay());
+    }
+
+    /**
+     * Returns the top 10 contributors ranked by post count, ordered by etl_rank ASC.
+     * Cached under "analyticsTopContributors".
+     */
+    @Cacheable("analyticsTopContributors")
+    @Async
+    public CompletableFuture<List<TopContributor>> getTopContributors() {
+        return CompletableFuture.completedFuture(topContributorsRepository.getTopContributors());
+    }
+}

--- a/backend/src/main/java/com/amalitech/communityboard/config/AppConfig.java
+++ b/backend/src/main/java/com/amalitech/communityboard/config/AppConfig.java
@@ -1,0 +1,33 @@
+package com.amalitech.communityboard.config;
+
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * CB-211: Application-level configuration for caching.
+ *
+ * Uses ConcurrentMapCacheManager — an in-memory, thread-safe cache backed by
+ * java.util.concurrent.ConcurrentHashMap. No external dependencies required.
+ *
+ * Cache regions:
+ *  "posts" — paginated post lists (evicted on any create/update/delete)
+ *  "post"  — single post by ID (evicted on update/delete of that specific post)
+ */
+@Configuration
+@EnableCaching
+public class AppConfig {
+
+    @Bean
+    public CacheManager cacheManager() {
+        return new ConcurrentMapCacheManager(
+                "posts", "post",
+                "analyticsSummary",
+                "analyticsPostsByCategory",
+                "analyticsPostsByDay",
+                "analyticsTopContributors"
+        );
+    }
+}

--- a/backend/src/main/java/com/amalitech/communityboard/config/AsyncConfig.java
+++ b/backend/src/main/java/com/amalitech/communityboard/config/AsyncConfig.java
@@ -1,0 +1,28 @@
+package com.amalitech.communityboard.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+/**
+ * Enables Spring's @Async support and configures a dedicated thread pool
+ * for analytics queries so they don't compete with the main request threads.
+ */
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "analyticsExecutor")
+    public Executor analyticsExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(2);
+        executor.setMaxPoolSize(4);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("analytics-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/backend/src/main/resources/db/migration/V5__create_analytics_views.sql
+++ b/backend/src/main/resources/db/migration/V5__create_analytics_views.sql
@@ -1,0 +1,109 @@
+-- =============================================================
+-- CommunityBoard Analytics Views - Flyway Migration V5
+-- Creates materialized views consumed by the analytics API.
+--
+-- These views are also managed by the data-engineering ETL
+-- pipeline (01_create_analytics_views.sql).  Creating them here
+-- ensures the application starts cleanly even when the ETL
+-- container is not running.  When the ETL runs it will call
+-- REFRESH MATERIALIZED VIEW CONCURRENTLY to populate live data.
+--
+-- IMPORTANT NOTE ON ORDERING:
+--   PostgreSQL materialized views do NOT guarantee row order.
+--   The unique indexes below (BTREE) enable efficient ORDER BY
+--   queries.  The backend API always queries with an explicit
+--   ORDER BY clause — do not rely on view-internal ordering.
+-- =============================================================
+
+
+-- -------------------------------------------------------------
+-- VIEW 1: SUMMARY
+-- API endpoint: GET /api/analytics/summary
+-- -------------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS analytics_summary AS
+SELECT
+    (SELECT COUNT(*) FROM posts)    AS total_posts,
+    (SELECT COUNT(*) FROM comments) AS total_comments;
+
+
+-- -------------------------------------------------------------
+-- VIEW 2: POSTS BY CATEGORY
+-- All 4 categories always appear even when count is 0.
+-- API endpoint: GET /api/analytics/posts-by-category
+-- -------------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS analytics_posts_by_category AS
+SELECT
+    category_name,
+    COUNT(p.id) AS post_count
+FROM (
+    VALUES ('NEWS'), ('EVENT'), ('DISCUSSION'), ('ALERT')
+) AS all_categories(category_name)
+LEFT JOIN posts p ON p.category::TEXT = all_categories.category_name
+GROUP BY category_name;
+
+
+-- -------------------------------------------------------------
+-- VIEW 3: POSTS BY DAY OF WEEK
+-- All 7 days always appear even when count is 0.
+-- API endpoint: GET /api/analytics/posts-by-day
+-- -------------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS analytics_posts_by_day AS
+SELECT
+    day_name,
+    day_order,
+    COUNT(p.id) AS post_count
+FROM (
+    VALUES
+        ('Sun', 0),
+        ('Mon', 1),
+        ('Tue', 2),
+        ('Wed', 3),
+        ('Thu', 4),
+        ('Fri', 5),
+        ('Sat', 6)
+) AS all_days(day_name, day_order)
+LEFT JOIN posts p
+    ON EXTRACT(DOW FROM p.created_at)::INT = all_days.day_order
+GROUP BY day_name, day_order;
+
+
+-- -------------------------------------------------------------
+-- VIEW 4: TOP 10 CONTRIBUTORS
+-- etl_rank  → unique sequential number (required for CONCURRENT refresh)
+-- true_rank → leaderboard rank (tied users share the same rank)
+-- API endpoint: GET /api/analytics/contributors/top
+-- -------------------------------------------------------------
+CREATE MATERIALIZED VIEW IF NOT EXISTS analytics_top_contributors AS
+WITH ranked_contributors AS (
+    SELECT
+        ROW_NUMBER() OVER (ORDER BY COUNT(p.id) DESC, u.id ASC) AS etl_rank,
+        RANK()       OVER (ORDER BY COUNT(p.id) DESC)           AS true_rank,
+        u.id                                                     AS user_id,
+        u.name                                                   AS contributor_name,
+        u.email                                                  AS contributor_email,
+        COUNT(p.id)                                              AS post_count
+    FROM users u
+    LEFT JOIN posts p ON p.author_id = u.id
+    GROUP BY u.id, u.name, u.email
+)
+SELECT *
+FROM ranked_contributors
+LIMIT 10;
+
+
+-- -------------------------------------------------------------
+-- UNIQUE INDEXES
+-- Required for CONCURRENT refresh (non-blocking view refresh).
+-- BTREE type (default) also enables efficient ORDER BY queries.
+-- -------------------------------------------------------------
+CREATE UNIQUE INDEX IF NOT EXISTS idx_analytics_summary_posts
+    ON analytics_summary(total_posts);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_analytics_category_name
+    ON analytics_posts_by_category(category_name);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_analytics_day_order
+    ON analytics_posts_by_day(day_order);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_analytics_contributor_etl_rank
+    ON analytics_top_contributors(etl_rank);

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,6 +8,7 @@ import { Register } from "./pages/Register/Register";
 import { PostFeed } from "./pages/PostFeed/PostFeed";
 import { PostDetails } from "./pages/PostDetails/PostDetails";
 import { CreatePost } from "./pages/CreatePost/CreatePost";
+import { Analytics } from "./pages/Analytics/Analytics";
 
 const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
   const { user } = useAuth();
@@ -37,6 +38,14 @@ export default function App() {
               element={
                 <ProtectedRoute>
                   <PostDetails />
+                </ProtectedRoute>
+              }
+            />
+            <Route
+              path="/analytics"
+              element={
+                <ProtectedRoute>
+                  <Analytics />
                 </ProtectedRoute>
               }
             />

--- a/frontend/src/pages/Analytics/Analytics.css
+++ b/frontend/src/pages/Analytics/Analytics.css
@@ -1,0 +1,356 @@
+/* Analytics Page */
+.analytics-page-container {
+  min-height: 100vh;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  background-color: var(--background-light);
+}
+
+.analytics-main-content {
+  width: 100%;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 32px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+/* Loading / Error */
+.analytics-loading,
+.analytics-error {
+  font-size: 14px;
+  font-family: "Inter", sans-serif;
+  text-align: center;
+  padding: 40px 0;
+}
+
+.analytics-error {
+  color: var(--error-text);
+}
+
+/* Content layout */
+.analytics-content {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+/* Stat Cards */
+.analytics-stat-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.analytics-stat-card {
+  background: var(--background-light);
+  border: 1px solid var(--input-border-light);
+  border-radius: 14px;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.analytics-stat-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  height: 40px;
+}
+
+.analytics-stat-title {
+  font-family: "Inter", sans-serif;
+  font-weight: 500;
+  font-size: 18px;
+  line-height: 1.5;
+  color: var(--body-text-secondary);
+}
+
+.analytics-stat-icon {
+  width: 40px;
+  height: 40px;
+  border-radius: 10px;
+  background: #cde6fc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.analytics-stat-value {
+  font-family: "Poppins", sans-serif;
+  font-weight: 600;
+  font-size: 24px;
+  line-height: 1.5;
+  color: var(--body-text-primary);
+}
+
+/* Chart Cards */
+.analytics-charts {
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+.analytics-chart-card {
+  background: var(--background-light);
+  border: 1px solid var(--input-border-light);
+  border-radius: 8px;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.analytics-chart-title {
+  font-family: "Inter", sans-serif;
+  font-weight: 600;
+  font-size: 18px;
+  line-height: 1.5;
+  color: var(--body-text-primary);
+  padding: 8px 0;
+}
+
+.analytics-chart-container {
+  display: flex;
+  gap: 16px;
+  align-items: stretch;
+}
+
+.analytics-chart-y-axis {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  height: 188px;
+  text-align: right;
+  flex-shrink: 0;
+}
+
+.analytics-chart-y-label {
+  font-family: "Inter", sans-serif;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--body-text-tertiary);
+}
+
+.analytics-chart-body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  min-width: 0;
+  position: relative;
+}
+
+.analytics-chart-grid {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 188px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  pointer-events: none;
+}
+
+.analytics-chart-grid-line {
+  width: 100%;
+  height: 1px;
+  border-top: 1px dashed var(--input-border, #b2bcc2);
+  background: transparent;
+}
+
+.analytics-chart-avg-line {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 0;
+  border-top: 2px dashed #393cc9;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.analytics-chart-bars {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  height: 188px;
+  gap: 8px;
+  position: relative;
+  z-index: 1;
+}
+
+.analytics-bar-wrapper {
+  flex: 1;
+  display: flex;
+  align-items: flex-end;
+  justify-content: center;
+  height: 100%;
+}
+
+.analytics-bar {
+  width: 100%;
+  max-width: 54px;
+  background: var(--Body-Text-Secondary, #395362);
+  border-radius: 2px 2px 0 0;
+  min-height: 0;
+  transition: height 0.3s ease;
+  position: relative;
+}
+
+.analytics-bar-tooltip {
+  display: none;
+  position: absolute;
+  top: -32px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--btn-primary-bg, #08283b);
+  color: #fff;
+  font-family: "Inter", sans-serif;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 10px;
+  border-radius: 6px;
+  white-space: nowrap;
+  pointer-events: none;
+  z-index: 10;
+}
+
+.analytics-bar:hover .analytics-bar-tooltip {
+  display: block;
+}
+
+.analytics-chart-x-axis {
+  display: flex;
+  justify-content: space-between;
+  text-align: center;
+}
+
+.analytics-chart-x-label {
+  flex: 1;
+  font-family: "Inter", sans-serif;
+  font-weight: 500;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--body-text-tertiary);
+  text-align: center;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Contributors Table */
+.analytics-contributors {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.analytics-contributors-title {
+  font-family: "Inter", sans-serif;
+  font-weight: 700;
+  font-size: 20px;
+  line-height: 1.5;
+  color: var(--body-text-primary);
+}
+
+.analytics-table-wrapper {
+  background: var(--background-light);
+  border-radius: 8px;
+  box-shadow:
+    0px 1px 3px 0px rgba(0, 0, 0, 0.1),
+    0px 1px 2px 0px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+}
+
+.analytics-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: "Inter", sans-serif;
+}
+
+.analytics-th {
+  background: var(--input-border-light);
+  padding: 16px;
+  font-weight: 600;
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--body-text-primary);
+  text-align: left;
+  border-bottom: 1px solid var(--input-border-light);
+  height: 56px;
+}
+
+.analytics-th-rank {
+  width: 80px;
+}
+
+.analytics-th-posts {
+  width: 80px;
+}
+
+.analytics-td {
+  padding: 16px;
+  font-weight: 400;
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--body-text-primary);
+  border-bottom: 1px solid var(--input-border-light);
+  background: var(--background-light);
+  min-height: 56px;
+}
+
+.analytics-td-rank {
+  width: 80px;
+}
+
+.analytics-td-posts {
+  width: 80px;
+}
+
+.analytics-empty-row {
+  text-align: center;
+  color: var(--body-text-tertiary);
+  font-size: 14px;
+}
+
+/* Desktop responsive */
+@media (min-width: 768px) {
+  .analytics-main-content {
+    padding: 40px 120px;
+  }
+
+  .analytics-stat-cards {
+    flex-direction: row;
+  }
+
+  .analytics-stat-card {
+    flex: 1;
+  }
+
+  .analytics-charts {
+    flex-direction: row;
+  }
+
+  .analytics-chart-card {
+    flex: 1;
+  }
+
+  .analytics-bar {
+    max-width: 54px;
+  }
+}
+
+@media (max-width: 767px) {
+  .analytics-bar {
+    max-width: 40px;
+  }
+
+  .analytics-chart-x-label {
+    font-size: 10px;
+  }
+}

--- a/frontend/src/pages/Analytics/Analytics.test.tsx
+++ b/frontend/src/pages/Analytics/Analytics.test.tsx
@@ -1,0 +1,234 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { BrowserRouter } from "react-router-dom";
+import { AuthProvider } from "../../context/AuthContext";
+import { ToastProvider } from "../../context/ToastContext";
+import { Analytics } from "./Analytics";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock useAuth
+vi.mock("../../context/AuthContext", async () => {
+  const actual = await vi.importActual("../../context/AuthContext");
+  return {
+    ...(actual as any),
+    useAuth: () => ({
+      user: { name: "Test User", email: "test@example.com" },
+      logout: vi.fn(),
+    }),
+  };
+});
+
+// Mock api
+const mockGet = vi.fn();
+vi.mock("../../services/api", () => ({
+  default: {
+    get: (...args: any[]) => mockGet(...args),
+    interceptors: {
+      request: { use: vi.fn() },
+      response: { use: vi.fn() },
+    },
+  },
+}));
+
+const mockPosts = [
+  {
+    id: 1,
+    title: "Event Post",
+    body: "Body 1",
+    category: "EVENT",
+    authorName: "Alice",
+    authorEmail: "alice@example.com",
+    createdAt: "2025-01-06T10:00:00", // Monday
+    updatedAt: "2025-01-06T10:00:00",
+    commentCount: 5,
+  },
+  {
+    id: 2,
+    title: "News Post",
+    body: "Body 2",
+    category: "NEWS",
+    authorName: "Alice",
+    authorEmail: "alice@example.com",
+    createdAt: "2025-01-07T10:00:00", // Tuesday
+    updatedAt: "2025-01-07T10:00:00",
+    commentCount: 3,
+  },
+  {
+    id: 3,
+    title: "Discussion Post",
+    body: "Body 3",
+    category: "DISCUSSION",
+    authorName: "Bob",
+    authorEmail: "bob@example.com",
+    createdAt: "2025-01-08T10:00:00", // Wednesday
+    updatedAt: "2025-01-08T10:00:00",
+    commentCount: 10,
+  },
+  {
+    id: 4,
+    title: "Alert Post",
+    body: "Body 4",
+    category: "ALERT",
+    authorName: "Charlie",
+    authorEmail: "charlie@example.com",
+    createdAt: "2025-01-06T15:00:00", // Monday
+    updatedAt: "2025-01-06T15:00:00",
+    commentCount: 2,
+  },
+  {
+    id: 5,
+    title: "Another Event",
+    body: "Body 5",
+    category: "EVENT",
+    authorName: "Alice",
+    authorEmail: "alice@example.com",
+    createdAt: "2025-01-10T10:00:00", // Friday
+    updatedAt: "2025-01-10T10:00:00",
+    commentCount: 7,
+  },
+];
+
+describe("Analytics Component", () => {
+  const renderAnalytics = () => {
+    return render(
+      <BrowserRouter>
+        <ToastProvider>
+          <AuthProvider>
+            <Analytics />
+          </AuthProvider>
+        </ToastProvider>
+      </BrowserRouter>,
+    );
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders loading state initially", () => {
+    mockGet.mockReturnValue(new Promise(() => {})); // never resolves
+    renderAnalytics();
+    expect(screen.getByText("Loading analytics...")).toBeInTheDocument();
+  });
+
+  it("renders breadcrumb navigation", async () => {
+    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    renderAnalytics();
+
+    await waitFor(() => {
+      expect(screen.getByText("Home")).toBeInTheDocument();
+      expect(
+        screen.getByText("Analytics", {
+          selector: ".breadcrumb-active",
+        }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("displays total posts count", async () => {
+    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    renderAnalytics();
+
+    await waitFor(() => {
+      expect(screen.getByText("Total Posts")).toBeInTheDocument();
+      const statValues = screen.getAllByText("5");
+      expect(statValues.length).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  it("displays total comments count", async () => {
+    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    renderAnalytics();
+
+    await waitFor(() => {
+      expect(screen.getByText("Total Comments")).toBeInTheDocument();
+      expect(screen.getByText("27")).toBeInTheDocument(); // 5+3+10+2+7
+    });
+  });
+
+  it("renders Posts by Category chart", async () => {
+    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    renderAnalytics();
+
+    await waitFor(() => {
+      expect(screen.getByText("Posts by Category")).toBeInTheDocument();
+      expect(screen.getByText("Events")).toBeInTheDocument();
+      expect(screen.getByText("News")).toBeInTheDocument();
+      expect(screen.getByText("Discussion")).toBeInTheDocument();
+      expect(screen.getByText("Alerts")).toBeInTheDocument();
+    });
+  });
+
+  it("renders Posts Day of Week chart", async () => {
+    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    renderAnalytics();
+
+    await waitFor(() => {
+      expect(screen.getByText("Posts Day of Week")).toBeInTheDocument();
+      expect(screen.getByText("Mon")).toBeInTheDocument();
+      expect(screen.getByText("Fri")).toBeInTheDocument();
+      expect(screen.getByText("Sun")).toBeInTheDocument();
+    });
+  });
+
+  it("renders Top 10 Contributors table", async () => {
+    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    renderAnalytics();
+
+    await waitFor(() => {
+      expect(screen.getByText("Top 10 Contributors")).toBeInTheDocument();
+      expect(screen.getByText("Alice")).toBeInTheDocument();
+      expect(screen.getByText("Bob")).toBeInTheDocument();
+      expect(screen.getByText("Charlie")).toBeInTheDocument();
+    });
+  });
+
+  it("shows correct contributor rankings sorted by post count", async () => {
+    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    renderAnalytics();
+
+    await waitFor(() => {
+      const rows = screen.getAllByRole("row");
+      // Header row + 3 data rows
+      expect(rows).toHaveLength(4);
+
+      // Alice has 3 posts (rank 1), Bob has 1 (rank 2), Charlie has 1 (rank 3)
+      const cells = screen.getAllByRole("cell");
+      // Row 1: rank 1, Alice, 3
+      expect(cells[0]).toHaveTextContent("1");
+      expect(cells[1]).toHaveTextContent("Alice");
+      expect(cells[2]).toHaveTextContent("3");
+    });
+  });
+
+  it("displays error message when API call fails", async () => {
+    mockGet.mockRejectedValue(new Error("Network error"));
+    renderAnalytics();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText("Failed to load analytics data. Please try again."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("shows empty state for contributors when no posts", async () => {
+    mockGet.mockResolvedValue({ data: { content: [] } });
+    renderAnalytics();
+
+    await waitFor(() => {
+      expect(screen.getByText("No contributors yet")).toBeInTheDocument();
+    });
+  });
+
+  it("fetches posts with correct API params", async () => {
+    mockGet.mockResolvedValue({ data: { content: [] } });
+    renderAnalytics();
+
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalledWith("/posts", {
+        params: { page: 0, size: 1000 },
+      });
+    });
+  });
+});

--- a/frontend/src/pages/Analytics/Analytics.tsx
+++ b/frontend/src/pages/Analytics/Analytics.tsx
@@ -1,0 +1,297 @@
+import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import { Navbar } from "../../components/layout/Navbar";
+import api from "../../services/api";
+import "./Analytics.css";
+import "../PostDetails/PostDetails.css";
+
+// --- API response shapes (matching what the backend ACTUALLY returns) ---
+// Note: The backend entities use Lombok @Getter which serializes Java field names
+// directly. These differ from Percy's api_contract.md in some cases.
+
+interface SummaryResponse {
+  totalPosts: number;
+  totalComments: number;
+}
+
+interface CategoryResponse {
+  categoryName: string;  // backend field: categoryName (contract says "category")
+  postCount: number;     // backend field: postCount (contract says "count")
+}
+
+interface DayResponse {
+  dayName: string;       // backend field: dayName (contract says "day")
+  dayOrder: number;      // 0=Sun, 1=Mon, ..., 6=Sat
+  postCount: number;     // backend field: postCount (contract says "count")
+}
+
+interface ContributorResponse {
+  etlRank: number;           // unique row number (used internally)
+  trueRank: number;          // dense rank — tied users share the same value
+  userId: number;
+  contributorName: string;   // backend field: contributorName (contract says "name")
+  contributorEmail: string;  // backend field: contributorEmail (contract says "email")
+  postCount: number;
+}
+
+// Display labels for the category bar chart
+const CATEGORY_LABELS: Record<string, string> = {
+  EVENT: "Events",
+  NEWS: "News",
+  DISCUSSION: "Discussion",
+  ALERT: "Alerts",
+};
+
+function BarChart({
+  data,
+  title,
+}: {
+  data: { label: string; count: number }[];
+  title: string;
+}) {
+  const maxValue = Math.max(...data.map((d) => d.count), 1);
+  // Round up to nearest nice number for y-axis
+  const yMax = Math.ceil(maxValue / 10) * 10 || 10;
+  const yTicks = [
+    ...new Set([
+      yMax,
+      Math.round((yMax * 3) / 4),
+      Math.round(yMax / 2),
+      Math.round(yMax / 4),
+      0,
+    ]),
+  ];
+  const avg =
+    data.length > 0
+      ? data.reduce((sum, d) => sum + d.count, 0) / data.length
+      : 0;
+  const avgPosition = yMax > 0 ? (avg / yMax) * 100 : 0;
+
+  return (
+    <div className="analytics-chart-card">
+      <h3 className="analytics-chart-title">{title}</h3>
+      <div className="analytics-chart-container">
+        <div className="analytics-chart-y-axis">
+          {yTicks.map((tick) => (
+            <span key={tick} className="analytics-chart-y-label">
+              {tick}
+            </span>
+          ))}
+        </div>
+        <div className="analytics-chart-body">
+          <div className="analytics-chart-grid">
+            {yTicks.map((tick) => (
+              <div key={tick} className="analytics-chart-grid-line" />
+            ))}
+          </div>
+          <div className="analytics-chart-bars">
+            <div
+              className="analytics-chart-avg-line"
+              style={{ bottom: `${avgPosition}%` }}
+            />
+            {data.map((d) => (
+              <div key={d.label} className="analytics-bar-wrapper">
+                <div
+                  className="analytics-bar"
+                  style={{
+                    height: `${yMax > 0 ? (d.count / yMax) * 100 : 0}%`,
+                  }}
+                >
+                  <span className="analytics-bar-tooltip">
+                    Count: {d.count}
+                  </span>
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="analytics-chart-x-axis">
+            {data.map((d) => (
+              <span key={d.label} className="analytics-chart-x-label">
+                {d.label}
+              </span>
+            ))}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function Analytics() {
+  const navigate = useNavigate();
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  const [summary, setSummary] = useState<SummaryResponse>({ totalPosts: 0, totalComments: 0 });
+  const [categoryData, setCategoryData] = useState<{ label: string; count: number }[]>([]);
+  const [dayData, setDayData] = useState<{ label: string; count: number }[]>([]);
+  const [contributors, setContributors] = useState<ContributorResponse[]>([]);
+
+  useEffect(() => {
+    const fetchAnalytics = async () => {
+      setLoading(true);
+      try {
+        // Fire all 4 requests simultaneously — no reason to wait for one before the next
+        const [summaryRes, categoryRes, dayRes, contributorsRes] = await Promise.all([
+          api.get<SummaryResponse>("/analytics/summary"),
+          api.get<CategoryResponse[]>("/analytics/posts-by-category"),
+          api.get<DayResponse[]>("/analytics/posts-by-day"),
+          api.get<ContributorResponse[]>("/analytics/contributors/top"),
+        ]);
+
+        setSummary(summaryRes.data);
+
+        // Map API categoryName keys to display labels for the chart
+        setCategoryData(
+          categoryRes.data.map((d) => ({
+            label: CATEGORY_LABELS[d.categoryName] || d.categoryName,
+            count: d.postCount,
+          })),
+        );
+
+        // Sort by dayOrder (0=Sun…6=Sat) so the chart axis is always in week order
+        setDayData(
+          [...dayRes.data]
+            .sort((a, b) => a.dayOrder - b.dayOrder)
+            .map((d) => ({ label: d.dayName, count: d.postCount })),
+        );
+
+        setContributors(contributorsRes.data);
+        setError("");
+      } catch (err) {
+        console.error("Failed to load analytics data", err);
+        setError("Failed to load analytics data. Please try again.");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchAnalytics();
+  }, []);
+
+  return (
+    <div className="analytics-page-container">
+      <Navbar />
+
+      <main className="analytics-main-content">
+        {/* Breadcrumb */}
+        <div className="breadcrumb-container">
+          <img
+            src="/assets/house.svg"
+            alt="Home"
+            className="breadcrumb-icon-img breadcrumb-clickable"
+            onClick={() => navigate("/")}
+          />
+          <span
+            className="breadcrumb-text breadcrumb-clickable"
+            onClick={() => navigate("/")}
+          >
+            Home
+          </span>
+          <img
+            src="/assets/chevron-right.svg"
+            alt="Arrow"
+            className="breadcrumb-icon-img"
+          />
+          <span className="breadcrumb-text breadcrumb-active">Analytics</span>
+        </div>
+
+        {loading && <p className="analytics-loading">Loading analytics...</p>}
+        {error && <p className="analytics-error">{error}</p>}
+
+        {!loading && !error && (
+          <div className="analytics-content">
+            {/* Stat Cards */}
+            <div className="analytics-stat-cards">
+              <div className="analytics-stat-card">
+                <div className="analytics-stat-header">
+                  <h3 className="analytics-stat-title">Total Posts</h3>
+                  <div className="analytics-stat-icon analytics-stat-icon-chart">
+                    <img
+                      src="/assets/trending-up.svg"
+                      alt="Trending up"
+                      width="20"
+                      height="20"
+                    />
+                  </div>
+                </div>
+                <p className="analytics-stat-value">{summary.totalPosts}</p>
+              </div>
+              <div className="analytics-stat-card">
+                <div className="analytics-stat-header">
+                  <h3 className="analytics-stat-title">Total Comments</h3>
+                  <div className="analytics-stat-icon analytics-stat-icon-comment">
+                    <img
+                      src="/assets/total-comments.svg"
+                      alt="Comments"
+                      width="20"
+                      height="20"
+                    />
+                  </div>
+                </div>
+                <p className="analytics-stat-value">
+                  {summary.totalComments}
+                </p>
+              </div>
+            </div>
+
+            {/* Charts */}
+            <div className="analytics-charts">
+              <BarChart
+                data={categoryData}
+                title="Posts by Category"
+              />
+              <BarChart
+                data={dayData}
+                title="Posts Day of Week"
+              />
+            </div>
+
+            {/* Top Contributors Table */}
+            <div className="analytics-contributors">
+              <h3 className="analytics-contributors-title">
+                Top 10 Contributors
+              </h3>
+              <div className="analytics-table-wrapper">
+                <table className="analytics-table">
+                  <thead>
+                    <tr>
+                      <th className="analytics-th analytics-th-rank">Ranks</th>
+                      <th className="analytics-th analytics-th-name">Name</th>
+                      <th className="analytics-th analytics-th-posts">Posts</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {contributors.length === 0 ? (
+                      <tr>
+                        <td
+                          colSpan={3}
+                          className="analytics-td analytics-empty-row"
+                        >
+                          No contributors yet
+                        </td>
+                      </tr>
+                    ) : (
+                      contributors.map((contributor) => (
+                        <tr key={`${contributor.etlRank}-${contributor.contributorName}`}>
+                          <td className="analytics-td analytics-td-rank">
+                            {contributor.trueRank}
+                          </td>
+                          <td className="analytics-td analytics-td-name">
+                            {contributor.contributorName}
+                          </td>
+                          <td className="analytics-td analytics-td-posts">
+                            {contributor.postCount}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Restore analytics backend + frontend files accidentally deleted in `b22b3ec` (squashed into a QA dep fix)
- Integrate frontend Analytics page with Percy's 4 ETL API endpoints
- Add `/analytics` route back to App.tsx

## What was deleted and is now restored
**Backend (10 files):** AnalyticsController, 4 JPA entities, 4 repositories, AnalyticsService, AppConfig, AsyncConfig, Flyway V5 migration

**Frontend (3 files):** Analytics.tsx (updated with ETL integration), Analytics.css, Analytics.test.tsx

## Frontend ETL Integration
The Analytics page now calls Percy's 4 materialized-view endpoints in parallel:
| Endpoint | Powers |
|---|---|
| `GET /api/analytics/summary` | Total Posts & Comments cards |
| `GET /api/analytics/posts-by-category` | Category bar chart |
| `GET /api/analytics/posts-by-day` | Day-of-week bar chart |
| `GET /api/analytics/contributors/top` | Top 10 contributors table |

## Test plan
- [ ] `docker-compose up --build` — all 4 services start
- [ ] Login and navigate to `/analytics`
- [ ] Verify summary cards show real totals
- [ ] Verify bar charts render with correct labels and counts
- [ ] Verify contributor table shows ranked users
- [ ] Create a new post and confirm analytics update within ~5 seconds

🤖 Generated with [Claude Code](https://claude.com/claude-code)