### PR TITLE
fix(test): rewrite Analytics tests for ETL endpoints

### DIFF
--- a/frontend/src/pages/Analytics/Analytics.test.tsx
+++ b/frontend/src/pages/Analytics/Analytics.test.tsx
@@ -1,5 +1,4 @@
 import { render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
 import { BrowserRouter } from "react-router-dom";
 import { AuthProvider } from "../../context/AuthContext";
 import { ToastProvider } from "../../context/ToastContext";
@@ -18,7 +17,7 @@ vi.mock("../../context/AuthContext", async () => {
   };
 });
 
-// Mock api
+// Mock api — route responses based on the URL argument
 const mockGet = vi.fn();
 vi.mock("../../services/api", () => ({
   default: {
@@ -30,63 +29,69 @@ vi.mock("../../services/api", () => ({
   },
 }));
 
-const mockPosts = [
+// --- Mock data matching backend field names ---
+
+const mockSummary = { totalPosts: 5, totalComments: 27 };
+
+const mockCategories = [
+  { categoryName: "EVENT", postCount: 2 },
+  { categoryName: "NEWS", postCount: 1 },
+  { categoryName: "DISCUSSION", postCount: 1 },
+  { categoryName: "ALERT", postCount: 1 },
+];
+
+const mockDays = [
+  { dayName: "Sun", dayOrder: 0, postCount: 0 },
+  { dayName: "Mon", dayOrder: 1, postCount: 2 },
+  { dayName: "Tue", dayOrder: 2, postCount: 1 },
+  { dayName: "Wed", dayOrder: 3, postCount: 1 },
+  { dayName: "Thu", dayOrder: 4, postCount: 0 },
+  { dayName: "Fri", dayOrder: 5, postCount: 1 },
+  { dayName: "Sat", dayOrder: 6, postCount: 0 },
+];
+
+const mockContributors = [
   {
-    id: 1,
-    title: "Event Post",
-    body: "Body 1",
-    category: "EVENT",
-    authorName: "Alice",
-    authorEmail: "alice@example.com",
-    createdAt: "2025-01-06T10:00:00", // Monday
-    updatedAt: "2025-01-06T10:00:00",
-    commentCount: 5,
+    etlRank: 1,
+    trueRank: 1,
+    userId: 1,
+    contributorName: "Alice",
+    contributorEmail: "alice@example.com",
+    postCount: 3,
   },
   {
-    id: 2,
-    title: "News Post",
-    body: "Body 2",
-    category: "NEWS",
-    authorName: "Alice",
-    authorEmail: "alice@example.com",
-    createdAt: "2025-01-07T10:00:00", // Tuesday
-    updatedAt: "2025-01-07T10:00:00",
-    commentCount: 3,
+    etlRank: 2,
+    trueRank: 2,
+    userId: 2,
+    contributorName: "Bob",
+    contributorEmail: "bob@example.com",
+    postCount: 1,
   },
   {
-    id: 3,
-    title: "Discussion Post",
-    body: "Body 3",
-    category: "DISCUSSION",
-    authorName: "Bob",
-    authorEmail: "bob@example.com",
-    createdAt: "2025-01-08T10:00:00", // Wednesday
-    updatedAt: "2025-01-08T10:00:00",
-    commentCount: 10,
-  },
-  {
-    id: 4,
-    title: "Alert Post",
-    body: "Body 4",
-    category: "ALERT",
-    authorName: "Charlie",
-    authorEmail: "charlie@example.com",
-    createdAt: "2025-01-06T15:00:00", // Monday
-    updatedAt: "2025-01-06T15:00:00",
-    commentCount: 2,
-  },
-  {
-    id: 5,
-    title: "Another Event",
-    body: "Body 5",
-    category: "EVENT",
-    authorName: "Alice",
-    authorEmail: "alice@example.com",
-    createdAt: "2025-01-10T10:00:00", // Friday
-    updatedAt: "2025-01-10T10:00:00",
-    commentCount: 7,
+    etlRank: 3,
+    trueRank: 2,
+    userId: 3,
+    contributorName: "Charlie",
+    contributorEmail: "charlie@example.com",
+    postCount: 1,
   },
 ];
+
+/** Route mockGet responses by URL path */
+function setupMockEndpoints(overrides?: Partial<Record<string, any>>) {
+  mockGet.mockImplementation((url: string) => {
+    const responses: Record<string, any> = {
+      "/analytics/summary": { data: mockSummary },
+      "/analytics/posts-by-category": { data: mockCategories },
+      "/analytics/posts-by-day": { data: mockDays },
+      "/analytics/contributors/top": { data: mockContributors },
+      ...overrides,
+    };
+    const match = responses[url];
+    if (match instanceof Error) return Promise.reject(match);
+    return Promise.resolve(match ?? { data: [] });
+  });
+}
 
 describe("Analytics Component", () => {
   const renderAnalytics = () => {
@@ -112,7 +117,7 @@ describe("Analytics Component", () => {
   });
 
   it("renders breadcrumb navigation", async () => {
-    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    setupMockEndpoints();
     renderAnalytics();
 
     await waitFor(() => {
@@ -126,7 +131,7 @@ describe("Analytics Component", () => {
   });
 
   it("displays total posts count", async () => {
-    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    setupMockEndpoints();
     renderAnalytics();
 
     await waitFor(() => {
@@ -137,17 +142,17 @@ describe("Analytics Component", () => {
   });
 
   it("displays total comments count", async () => {
-    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    setupMockEndpoints();
     renderAnalytics();
 
     await waitFor(() => {
       expect(screen.getByText("Total Comments")).toBeInTheDocument();
-      expect(screen.getByText("27")).toBeInTheDocument(); // 5+3+10+2+7
+      expect(screen.getByText("27")).toBeInTheDocument();
     });
   });
 
   it("renders Posts by Category chart", async () => {
-    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    setupMockEndpoints();
     renderAnalytics();
 
     await waitFor(() => {
@@ -160,7 +165,7 @@ describe("Analytics Component", () => {
   });
 
   it("renders Posts Day of Week chart", async () => {
-    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    setupMockEndpoints();
     renderAnalytics();
 
     await waitFor(() => {
@@ -172,7 +177,7 @@ describe("Analytics Component", () => {
   });
 
   it("renders Top 10 Contributors table", async () => {
-    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    setupMockEndpoints();
     renderAnalytics();
 
     await waitFor(() => {
@@ -184,7 +189,7 @@ describe("Analytics Component", () => {
   });
 
   it("shows correct contributor rankings sorted by post count", async () => {
-    mockGet.mockResolvedValue({ data: { content: mockPosts } });
+    setupMockEndpoints();
     renderAnalytics();
 
     await waitFor(() => {
@@ -192,9 +197,8 @@ describe("Analytics Component", () => {
       // Header row + 3 data rows
       expect(rows).toHaveLength(4);
 
-      // Alice has 3 posts (rank 1), Bob has 1 (rank 2), Charlie has 1 (rank 3)
       const cells = screen.getAllByRole("cell");
-      // Row 1: rank 1, Alice, 3
+      // Row 1: trueRank 1, Alice, 3
       expect(cells[0]).toHaveTextContent("1");
       expect(cells[1]).toHaveTextContent("Alice");
       expect(cells[2]).toHaveTextContent("3");
@@ -213,7 +217,12 @@ describe("Analytics Component", () => {
   });
 
   it("shows empty state for contributors when no posts", async () => {
-    mockGet.mockResolvedValue({ data: { content: [] } });
+    setupMockEndpoints({
+      "/analytics/summary": { data: { totalPosts: 0, totalComments: 0 } },
+      "/analytics/posts-by-category": { data: [] },
+      "/analytics/posts-by-day": { data: [] },
+      "/analytics/contributors/top": { data: [] },
+    });
     renderAnalytics();
 
     await waitFor(() => {
@@ -221,14 +230,15 @@ describe("Analytics Component", () => {
     });
   });
 
-  it("fetches posts with correct API params", async () => {
-    mockGet.mockResolvedValue({ data: { content: [] } });
+  it("fetches all 4 analytics endpoints", async () => {
+    setupMockEndpoints();
     renderAnalytics();
 
     await waitFor(() => {
-      expect(mockGet).toHaveBeenCalledWith("/posts", {
-        params: { page: 0, size: 1000 },
-      });
+      expect(mockGet).toHaveBeenCalledWith("/analytics/summary");
+      expect(mockGet).toHaveBeenCalledWith("/analytics/posts-by-category");
+      expect(mockGet).toHaveBeenCalledWith("/analytics/posts-by-day");
+      expect(mockGet).toHaveBeenCalledWith("/analytics/contributors/top");
     });
   });
 });


### PR DESCRIPTION
## Summary
- Rewrites `Analytics.test.tsx` to mock the 4 separate ETL analytics endpoints (`/analytics/summary`, `/analytics/posts-by-category`, `/analytics/posts-by-day`, `/analytics/contributors/top`) instead of the old single `/posts` endpoint
- Fixes the frontend test failures from PR #100
- Uses lowercase branch name to pass branch name CI validation

## Test plan
- [x] All 11 Analytics tests pass locally (`npx vitest run`)
- [ ] CI pipeline passes (branch name validation + frontend tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)